### PR TITLE
修正12.1.1标点误用 (#3)

### DIFF
--- a/src/apps.tex
+++ b/src/apps.tex
@@ -17,7 +17,7 @@
 ...%设置中文
 \begin{document}
 \begin{frame}{`最大之乘，最正之宗`}
-`若菩萨有我相，人相，众生相，寿者相。即非菩萨。`
+`若菩萨有我相、人相、众生相、寿者相，即非菩萨。`
 \end{frame}
 \end{document}
 \end{Code}


### PR DESCRIPTION
若菩萨有我相，人相，众生相，寿者相。即非菩萨。 -> 若菩萨有我相、人相、众生相、寿者相，即非菩萨。